### PR TITLE
feat: Support high density pixel displays

### DIFF
--- a/lib/pdf417.js
+++ b/lib/pdf417.js
@@ -594,9 +594,14 @@ var PDF417 = {
 		}
 
         var barcode = this.barcode_array
-        canvas.width = barcode['num_cols']
-        canvas.height = barcode['num_rows']
+        // A canvas can appear too blurry on retina screens.
+        // Use window.devicePixelRatio to determine how much 
+        // extra pixel density should be added to allow for a sharper image.
+        var retinaMultiplier = window ? window.devicePixelRatio || 1 : 1
+        canvas.width = barcode['num_cols'] * retinaMultiplier
+        canvas.height = barcode['num_rows'] * retinaMultiplier
         var ctx = canvas.getContext('2d')
+        ctx.scale(retinaMultiplier,retinaMultiplier)
 
         // graph barcode elements
         // for each row and column


### PR DESCRIPTION
Thanks for this library. Very easy to use. I came across an issue where the canvas was displaying a blurry barcode on high density pixel displays (e.g., mobile phones). The solution is to use `window.devicePixelRatio` to determine how much extra pixel density should be added to allow for a sharper image.

I'm first checking to see that the window object exists to stay compatible with node (this is untested, but _should_ work). For more information on `window.devicePixelRatio`, please see the [MDN Web Docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/devicePixelRatio) where they use this same scenario with `canvas` as an example.

Hope it helps others.