### PR TITLE
Fix syntax error when attempting to load in ES modules.

### DIFF
--- a/lib/bcmath.js
+++ b/lib/bcmath.js
@@ -1,5 +1,6 @@
- if (typeof module !== 'undefined' && typeof module.exports !== 'undefined')
+ if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
      var libbcmath = require("./libbcmath")
+ }
 
 /**
  * PHP Implementation of the libbcmath functions


### PR DESCRIPTION
Fixes #10 

My best guess is that this didn't work because ES modules always run in
strict mode.

Here's a screenshot of the error:
![Screen Shot 2022-06-15 at 11 39 27 AM](https://user-images.githubusercontent.com/11037771/173880472-4c486458-1a74-440a-8e29-ca51af429e85.png)

